### PR TITLE
feat(init/settings): cleaner way to import env variables

### DIFF
--- a/server/.example.env
+++ b/server/.example.env
@@ -1,7 +1,9 @@
+APP_ENV=dev
 PORT=8001
 GRPC_SERVER_URI=https://localhost:8000
-DB_NAME=dalal_street_bots
+DB_NAME=dalalStreet_bots
 DB_PWD=password
 DB_USER=user
 DB_HOST=0.0.0.0
-
+DB_URI=scheme://user:password@localhost/dalalstreet_bots
+DB_SCHEME=mysql

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -1,31 +1,21 @@
-import os
+from functools import lru_cache
+from typing import Dict, Type
 
-from dotenv import dotenv_values
+from .settings.app import AppSettings
+from .settings.base import AppEnvTypes, BaseAppSettings
+from .settings.dev import DevAppSettings
+from .settings.prod import ProdAppSettings
+from .settings.test import TestAppSettings
 
-# TODO: add pydantic models to it
+environments: Dict[AppEnvTypes, Type[AppSettings]] = {
+    AppEnvTypes.dev: DevAppSettings,
+    AppEnvTypes.prod: ProdAppSettings,
+    AppEnvTypes.test: TestAppSettings,
+}
 
 
-def convertToInt(key: str, default: int) -> int:
-    data = config.get(key, str(default))
-    if data is None:
-        return default
-    else:
-        return int(data)
-
-
-_dir_path = os.path.dirname(os.path.realpath(__file__))
-_path = _dir_path + "/../../.env"
-config = dotenv_values(_path)
-# TODO: Clean this up
-PORT = convertToInt("PORT", 8001)
-
-# TODO: it would be nice if we add some check to see
-# if the env contains "http" or "https", and throw an error
-GRPC_SERVER_URI = config.get("GRPC_SERVER_URI", "localhost:8000")
-
-DB_NAME = config.get("DB_NAME", "dalal_street_bots")
-DB_PWD = config.get("DB_PWD", "password")
-DB_USER = config.get("DB_USER", "user")
-DB_HOST = config.get("DB_HOST", "0.0.0.0")
-
-DB_URI = f"mariadb://{DB_USER}:{DB_PWD}@{DB_HOST}/{DB_NAME}"
+@lru_cache
+def get_app_settings() -> AppSettings:
+    app_env = BaseAppSettings().app_env
+    config = environments[app_env]
+    return config()

--- a/server/app/core/settings/app.py
+++ b/server/app/core/settings/app.py
@@ -1,17 +1,22 @@
 from typing import Any, Dict
 
-from base import BaseAppSettings
+from pydantic import HttpUrl
+
+from .base import BaseAppSettings
 
 
 class AppSettings(BaseAppSettings):
     debug: bool = False
     reload: bool = False
+    port: int = 8000
 
     docs_url: str = "/docs"
     openapi_prefix: str = ""
     openapi_url: str = "/openapi.json"
     redoc_url: str = "/redoc"
     title: str = "Dalal Street Bots"
+
+    grpc_server_uri: HttpUrl = "https://localhost:8000"
 
     def fastapi_kwargs(self) -> Dict[str, Any]:
         return {

--- a/server/app/core/settings/app.py
+++ b/server/app/core/settings/app.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict
 
-from pydantic import Field, HttpUrl
-
 from base import BaseAppSettings
 
 
@@ -14,8 +12,6 @@ class AppSettings(BaseAppSettings):
     openapi_url: str = "/openapi.json"
     redoc_url: str = "/redoc"
     title: str = "Dalal Street Bots"
-
-    grpc_server_uri: HttpUrl = Field(...)
 
     def fastapi_kwargs(self) -> Dict[str, Any]:
         return {

--- a/server/app/core/settings/app.py
+++ b/server/app/core/settings/app.py
@@ -1,0 +1,29 @@
+from typing import Any, Dict
+
+from pydantic import Field, HttpUrl
+
+from base import BaseAppSettings
+
+
+class AppSettings(BaseAppSettings):
+    debug: bool = False
+    reload: bool = False
+
+    docs_url: str = "/docs"
+    openapi_prefix: str = ""
+    openapi_url: str = "/openapi.json"
+    redoc_url: str = "/redoc"
+    title: str = "Dalal Street Bots"
+
+    grpc_server_uri: HttpUrl = Field(...)
+
+    def fastapi_kwargs(self) -> Dict[str, Any]:
+        return {
+            "debug": self.debug,
+            "reload": self.reload,
+            "docs_url": self.docs_url,
+            "openapi_prefix": self.openapi_prefix,
+            "openapi_url": self.openapi_url,
+            "redoc_url": self.redoc_url,
+            "title": self.title,
+        }

--- a/server/app/core/settings/app.py
+++ b/server/app/core/settings/app.py
@@ -16,7 +16,7 @@ class AppSettings(BaseAppSettings):
     redoc_url: str = "/redoc"
     title: str = "Dalal Street Bots"
 
-    grpc_server_uri: HttpUrl = "https://localhost:8000"
+    grpc_server_uri: HttpUrl = HttpUrl(url="https://localhost:8000")
 
     def fastapi_kwargs(self) -> Dict[str, Any]:
         return {

--- a/server/app/core/settings/base.py
+++ b/server/app/core/settings/base.py
@@ -1,5 +1,4 @@
-from dataclasses import Field
-from pydantic import BaseSettings, Field, AnyHttpUrl, validator
+from pydantic import BaseSettings, validator
 from enum import Enum
 
 

--- a/server/app/core/settings/base.py
+++ b/server/app/core/settings/base.py
@@ -1,0 +1,27 @@
+from dataclasses import Field
+from pydantic import BaseSettings, Field, AnyHttpUrl, validator
+from enum import Enum
+
+
+class AppEnvTypes(Enum):
+    prod: str = "prod"
+    dev: str = "dev"
+    test: str = "test"
+
+
+class BaseAppSettings(BaseSettings):
+    """BaseSettings for the App"""
+
+    app_env: AppEnvTypes = AppEnvTypes.prod
+
+    @validator("app_env", pre=True)
+    def check_if_valid_value(cls, v):
+        if not v in AppEnvTypes._value2member_map_:
+            # setting it to prod so that forgetting to set APP_ENV
+            # doesn't cause any vulnerabilities
+            print('Not a valid app_env provided, setting it to "prod" by default')
+            return AppEnvTypes.prod
+        return v
+
+    class Config:
+        env_file = ".env"

--- a/server/app/core/settings/base.py
+++ b/server/app/core/settings/base.py
@@ -1,5 +1,6 @@
-from pydantic import BaseSettings, validator
+from pydantic import BaseSettings, validator, Field
 from enum import Enum
+from .database import DatabaseDsn
 
 
 class AppEnvTypes(Enum):
@@ -12,6 +13,8 @@ class BaseAppSettings(BaseSettings):
     """BaseSettings for the App"""
 
     app_env: AppEnvTypes = AppEnvTypes.prod
+
+    db: DatabaseDsn = Field(DatabaseDsn(_env_file=".env"))
 
     @validator("app_env", pre=True)
     def check_if_valid_value(cls, v):

--- a/server/app/core/settings/base.py
+++ b/server/app/core/settings/base.py
@@ -1,5 +1,7 @@
-from pydantic import BaseSettings, validator, Field
 from enum import Enum
+
+from pydantic import BaseSettings, Field, validator
+
 from .database import DatabaseDsn
 
 
@@ -14,11 +16,11 @@ class BaseAppSettings(BaseSettings):
 
     app_env: AppEnvTypes = AppEnvTypes.prod
 
-    db: DatabaseDsn = Field(DatabaseDsn(_env_file=".env"))
+    db: DatabaseDsn = Field(DatabaseDsn(_env_file=".env"))  # type: ignore
 
     @validator("app_env", pre=True)
-    def check_if_valid_value(cls, v):
-        if not v in AppEnvTypes._value2member_map_:
+    def check_if_valid_value(cls, v: AppEnvTypes) -> AppEnvTypes:
+        if v not in AppEnvTypes._value2member_map_:
             # setting it to prod so that forgetting to set APP_ENV
             # doesn't cause any vulnerabilities
             print('Not a valid app_env provided, setting it to "prod" by default')

--- a/server/app/core/settings/database.py
+++ b/server/app/core/settings/database.py
@@ -1,7 +1,7 @@
-from typing import Any, Optional, Dict
 import re
+from typing import Any, Dict, Optional
 
-from pydantic import AnyUrl, BaseSettings, root_validator, Field, create_model
+from pydantic import AnyUrl, BaseSettings, create_model, root_validator
 
 from ..utils import find_if_given_keys_exist_in_dict
 
@@ -16,7 +16,7 @@ class MySqlDsn(AnyUrl):
     }
     user_required = True
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:  # type: ignore
         super().__init__(*args, **kwargs)
         if self.path:
             # we add the db name to the MySqlDsn if it exists
@@ -62,7 +62,7 @@ class DatabaseDsn(BaseSettings):
             values.__setitem__("name", values.__getitem__("uri").name)
 
         elif isIndividualKeysPresent:
-            uri = f"{values.__getitem__('scheme')}://{values.__getitem__('user')}:{values.__getitem__('pwd')}@\{values.__getitem__('host')}/{values.__getitem__('name')}"
+            uri = "{scheme}://{user}:{pwd}@{host}/{name}".format_map(values)
             # TODO: There must be a cleaner way to do this
             x = create_model(
                 "MySqlDsn",
@@ -83,9 +83,7 @@ class DatabaseDsn(BaseSettings):
             values.__setitem__("uri", x)
         else:
             print("All the values", values)
-            raise ValueError(
-                "Database details not provided. Make sure you have provided all the details"
-            )
+            raise ValueError("Database details not provided.")
 
         return values
 

--- a/server/app/core/settings/database.py
+++ b/server/app/core/settings/database.py
@@ -82,11 +82,11 @@ class DatabaseDsn(BaseSettings):
             )
             values.__setitem__("uri", x)
         else:
+            print("All the values", values)
             raise ValueError(
                 "Database details not provided. Make sure you have provided all the details"
             )
 
-        print("All the values", values)
         return values
 
     class Config:

--- a/server/app/core/settings/database.py
+++ b/server/app/core/settings/database.py
@@ -1,0 +1,93 @@
+from typing import Any, Optional, Dict
+import re
+
+from pydantic import AnyUrl, BaseSettings, root_validator, Field, create_model
+
+from ..utils import find_if_given_keys_exist_in_dict
+
+
+class MySqlDsn(AnyUrl):
+    name: str = ""
+    allowed_schemes = {
+        "mysql",
+        "mariadb",
+        "mysqlx+srv",
+        "mariadb+srv",
+    }
+    user_required = True
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self.path:
+            # we add the db name to the MySqlDsn if it exists
+            # Or else we throw an error
+            normalized_db_name = self.path[1:]
+            valid_sql_db_name_pattern = "[0-9a-zA-Z$_]+"
+
+            result = re.match(valid_sql_db_name_pattern, normalized_db_name)
+            if result:
+                self.name = normalized_db_name
+            else:
+                raise ValueError(
+                    "'{0} is not a valid db name.'".format(normalized_db_name)
+                )
+        else:
+            raise ValueError("Database name has not been provided")
+        # return
+
+
+class DatabaseDsn(BaseSettings):
+    uri: Optional[MySqlDsn]
+    host: Optional[str]
+    scheme: Optional[str]
+    user: Optional[str]
+    pwd: Optional[str]
+    name: Optional[str]
+
+    @root_validator(pre=False)
+    def check_if_proper_url_is_provided(cls, values: Dict[str, Any]) -> Any:
+        isIndividualKeysPresent = find_if_given_keys_exist_in_dict(
+            values, ["host", "user", "pwd", "name", "scheme"]
+        )
+        isUriPresent = find_if_given_keys_exist_in_dict(values, ["uri"])
+
+        if isIndividualKeysPresent and isUriPresent:
+            return values
+
+        elif isUriPresent:
+            values.__setitem__("scheme", values.__getitem__("uri").scheme)
+            values.__setitem__("user", values.__getitem__("uri").user)
+            values.__setitem__("pwd", values.__getitem__("uri").password)
+            values.__setitem__("host", values.__getitem__("uri").host)
+            values.__setitem__("name", values.__getitem__("uri").name)
+
+        elif isIndividualKeysPresent:
+            uri = f"{values.__getitem__('scheme')}://{values.__getitem__('user')}:{values.__getitem__('pwd')}@\{values.__getitem__('host')}/{values.__getitem__('name')}"
+            # TODO: There must be a cleaner way to do this
+            x = create_model(
+                "MySqlDsn",
+                kwargs={
+                    "uri": uri,
+                    "scheme": values.__getitem__("scheme"),
+                    "user": values.__getitem__("user"),
+                    "password": values.__getitem__("pwd"),
+                    "host": values.__getitem__("host"),
+                    "tld": None,
+                    "host_type": "int_domain",
+                    "port": None,
+                    "path": "/" + values.__getitem__("name"),
+                    "query": None,
+                    "fragment": None,
+                },
+            )
+            values.__setitem__("uri", x)
+        else:
+            raise ValueError(
+                "Database details not provided. Make sure you have provided all the details"
+            )
+
+        print("All the values", values)
+        return values
+
+    class Config:
+        env_prefix = "DB_"

--- a/server/app/core/settings/dev.py
+++ b/server/app/core/settings/dev.py
@@ -1,0 +1,11 @@
+from pydantic import AnyHttpUrl, Field
+
+from app import AppSettings
+
+
+class DevAppSettings(AppSettings):
+    debug: bool = True
+    reload: bool = True
+    title: bool = "Dalal Street Bots - Dev"
+
+    grpc_server_uri: AnyHttpUrl = Field(...)

--- a/server/app/core/settings/dev.py
+++ b/server/app/core/settings/dev.py
@@ -8,4 +8,4 @@ class DevAppSettings(AppSettings):
     reload: bool = True
     title: str = "Dalal Street Bots - Dev"
 
-    grpc_server_uri: AnyHttpUrl = Field(...)
+    grpc_server_uri: AnyHttpUrl = Field(...)  # type: ignore

--- a/server/app/core/settings/dev.py
+++ b/server/app/core/settings/dev.py
@@ -1,11 +1,11 @@
 from pydantic import AnyHttpUrl, Field
 
-from app import AppSettings
+from .app import AppSettings
 
 
 class DevAppSettings(AppSettings):
     debug: bool = True
     reload: bool = True
-    title: bool = "Dalal Street Bots - Dev"
+    title: str = "Dalal Street Bots - Dev"
 
     grpc_server_uri: AnyHttpUrl = Field(...)

--- a/server/app/core/settings/prod.py
+++ b/server/app/core/settings/prod.py
@@ -1,0 +1,10 @@
+from pydantic import HttpUrl, Field
+
+from app import AppSettings
+
+
+class ProdAppSettings(AppSettings):
+
+    # In production, grpc url must bt a proper url with
+    # a valid top-level domain
+    grpc_server_uri: HttpUrl = Field(...)

--- a/server/app/core/settings/prod.py
+++ b/server/app/core/settings/prod.py
@@ -1,4 +1,4 @@
-from pydantic import HttpUrl, Field
+from pydantic import Field, HttpUrl
 
 from .app import AppSettings
 

--- a/server/app/core/settings/prod.py
+++ b/server/app/core/settings/prod.py
@@ -1,6 +1,6 @@
 from pydantic import HttpUrl, Field
 
-from app import AppSettings
+from .app import AppSettings
 
 
 class ProdAppSettings(AppSettings):

--- a/server/app/core/settings/test.py
+++ b/server/app/core/settings/test.py
@@ -1,6 +1,8 @@
 from pydantic import AnyHttpUrl, Field
 
-from app import AppSettings
+from .app import AppSettings
+
+from .database import DatabaseDsn
 
 
 class TestAppSettings(AppSettings):
@@ -9,6 +11,8 @@ class TestAppSettings(AppSettings):
     title: bool = "Dalal Street Bots - Test"
 
     grpc_server_uri: AnyHttpUrl = Field(...)
+
+    # db: DatabaseDsn = Field(DatabaseDsn(_env_file="test.env"))
 
     # Need to set the Log level to Debug
 

--- a/server/app/core/settings/test.py
+++ b/server/app/core/settings/test.py
@@ -1,0 +1,18 @@
+from pydantic import AnyHttpUrl, Field
+
+from app import AppSettings
+
+
+class TestAppSettings(AppSettings):
+    debug: bool = True
+    reload: bool = True
+    title: bool = "Dalal Street Bots - Test"
+
+    grpc_server_uri: AnyHttpUrl = Field(...)
+
+    # Need to set the Log level to Debug
+
+    class Config:
+        # We have a separete env for testing
+        # (which is yet to be implemented)
+        env_file = "test.env"

--- a/server/app/core/settings/test.py
+++ b/server/app/core/settings/test.py
@@ -2,15 +2,13 @@ from pydantic import AnyHttpUrl, Field
 
 from .app import AppSettings
 
-from .database import DatabaseDsn
-
 
 class TestAppSettings(AppSettings):
     debug: bool = True
     reload: bool = True
-    title: bool = "Dalal Street Bots - Test"
+    title: str = "Dalal Street Bots - Test"
 
-    grpc_server_uri: AnyHttpUrl = Field(...)
+    grpc_server_uri: AnyHttpUrl = Field(...)  # type: ignore
 
     # db: DatabaseDsn = Field(DatabaseDsn(_env_file="test.env"))
 

--- a/server/app/core/utils.py
+++ b/server/app/core/utils.py
@@ -1,0 +1,17 @@
+"""Imperative Logic for various tasks are contained in this file
+If any task can be abstracted into a separete function which does not 
+pertain to the function of that piece of code, it should be put here.
+So that that layer is more declarative
+"""
+
+from typing import Any, Dict, List
+
+
+def find_if_given_keys_exist_in_dict(dict: Dict[str, Any], keys: List[str]) -> bool:
+    """Checks if the given keys are present in the dict"""
+    isPresent: bool = True
+
+    for key in keys:
+        isPresent = isPresent and key in dict and dict.__getitem__(key) != None
+
+    return isPresent

--- a/server/app/core/utils.py
+++ b/server/app/core/utils.py
@@ -1,5 +1,5 @@
 """Imperative Logic for various tasks are contained in this file
-If any task can be abstracted into a separete function which does not 
+If any task can be abstracted into a separete function which does not
 pertain to the function of that piece of code, it should be put here.
 So that that layer is more declarative
 """
@@ -12,6 +12,6 @@ def find_if_given_keys_exist_in_dict(dict: Dict[str, Any], keys: List[str]) -> b
     isPresent: bool = True
 
     for key in keys:
-        isPresent = isPresent and key in dict and dict.__getitem__(key) != None
+        isPresent = isPresent and key in dict and dict.__getitem__(key) is not None
 
     return isPresent

--- a/server/app/db/migrations/env.py
+++ b/server/app/db/migrations/env.py
@@ -3,7 +3,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from app.core.config import DB_URI
+from app.core.config import get_app_settings
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -24,7 +24,7 @@ target_metadata = None
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
 
-config.set_main_option("sqlalchemy.url", DB_URI)
+config.set_main_option("sqlalchemy.url", get_app_settings().db.uri)
 
 
 def run_migrations_offline() -> None:

--- a/server/app/grpc_manager/base.py
+++ b/server/app/grpc_manager/base.py
@@ -2,7 +2,7 @@ import os
 
 import grpc
 import proto_build.DalalMessage_pb2_grpc as DalalMessage_pb2_grpc
-from core.config import GRPC_SERVER_URI
+from core.config import get_app_settings
 
 
 class GrpcManager:
@@ -15,7 +15,7 @@ class GrpcManager:
             cert = open(path).read().encode("utf8")
             creds = grpc.ssl_channel_credentials(cert)
             channel = grpc.secure_channel(
-                GRPC_SERVER_URI,
+                get_app_settings().grpc_server_uri,
                 creds,
                 options=(
                     (

--- a/server/app/main.py
+++ b/server/app/main.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import uvicorn
-from core.config import PORT
+from core.config import get_app_settings
 from fastapi import FastAPI
 from grpc_manager.base import GrpcManager
 
@@ -10,9 +10,9 @@ app = FastAPI()
 
 if __name__ == "__main__":
     grpc_manager = GrpcManager()
-    uvicorn.run("main:app", host="0.0.0.0", port=PORT, reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=get_app_settings().port)
 
-app = FastAPI(debug=True)
+app = FastAPI(**get_app_settings().fastapi_kwargs())
 
 
 @app.get("/")


### PR DESCRIPTION
Use pydantic to iimport env variables, which provide inbuilt data validation. Largely ~copied~ inspired from [here](https://rednafi.github.io/digressions/python/2020/06/03/python-configs.html).